### PR TITLE
Fix pagination and message loading logic for chat history

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -39,8 +39,8 @@ async def index(request: Request, user=Depends(get_user)):
             # Fallback for unexpected return type
             initial_messages = msg_data
             total_messages = len(msg_data)
-        # If we got exactly 20, there might be more
-        if len(initial_messages) == 20:
+        # If the total messages in the session exceeds 20, there are more older messages
+        if total_messages > 20:
             has_more = True
     
     user_settings = agent.get_user_settings(user)

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1140,11 +1140,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (window.INITIAL_MESSAGES && window.INITIAL_MESSAGES.length > 0) {
         if (chatWelcome) chatWelcome.classList.add('d-none');
         window.INITIAL_MESSAGES.forEach((msg, idx) => {
-            const msgDiv = createMessageDiv(msg.role, msg.content, null, null, idx);
+            const index = (msg.raw_index !== undefined) ? msg.raw_index : idx;
+            const msgDiv = createMessageDiv(msg.role, msg.content, null, null, index);
             if (msgDiv) chatContainer.appendChild(msgDiv);
         });
         chatContainer.scrollTop = chatContainer.scrollHeight;
-        currentOffset = window.INITIAL_MESSAGES.length;
+        currentOffset = 20; // Default limit used in index route
         window.HAS_INITIAL_MESSAGES = true;
     }
 
@@ -1205,7 +1206,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     chatContainer.scrollTop = chatContainer.scrollHeight - scrollHeightBefore;
                 }
                 
-                currentOffset += messages.length;
+                currentOffset = offset + limit;
                 
                 // Show/Hide Load More
                 if (currentOffset < total) {


### PR DESCRIPTION
This PR addresses issues with loading chat history, specifically when sessions contain tool use or non-text messages that are filtered from the UI.

Changes:
- Backend: Fixed "has_more" logic in the index route to check total message count instead of display count.
- Frontend: Corrected currentOffset increment logic and ensured initial message rendering uses raw message indices.